### PR TITLE
Fix misleading wording in partB-introducing-krm.md

### DIFF
--- a/2-how-krm-works/partB-introducing-krm.md
+++ b/2-how-krm-works/partB-introducing-krm.md
@@ -168,7 +168,7 @@ Here we can see that the Kubernetes scheduler spread out the 3 nginx pods across
 
 The key thing to take away from this section is that the Kubernetes APIServer, with its etcd backing store, is the single source of truth for all "nouns" - KRM objects - in the cluster. What this means is that the `nginx-deployment.yaml` file you applied to the cluster actually gets added to by the Kubernetes control plane, with info about its live state. 
 
-### 7. **Get your deployment out of the APIServer using `kubectl`**. 
+### 7. **Get your deployment from the APIServer using `kubectl`**. 
 
 ```
 kubectl get deployment nginx-deployment -o yaml 


### PR DESCRIPTION
When I first read "Get your deployment out of the APIServer...", I thought we were about the remove the deployment from the cluster. So I'm rewording "out of" to "from".
This may be subjective, so feel free to reject this pull-request.