### PR TITLE
Lab 4 - part D - Update Constrant spec to reflect new template schema

### DIFF
--- a/4-platform-admin/constraint-ext-services/constraint.yaml
+++ b/4-platform-admin/constraint-ext-services/constraint.yaml
@@ -3,6 +3,8 @@ apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sNoExternalServices
 metadata:
   name: dev-no-ext-services
+  annotations:
+    configsync.gke.io/cluster-name-selector: cymbal-dev
 spec:
   parameters:
     internalCIDRs: [ ] 

--- a/4-platform-admin/constraint-ext-services/constraint.yaml
+++ b/4-platform-admin/constraint-ext-services/constraint.yaml
@@ -3,7 +3,6 @@ apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sNoExternalServices
 metadata:
   name: dev-no-ext-services
-  annotations:
-    configsync.gke.io/cluster-name-selector: cymbal-dev
 spec:
-  internalCIDRs: []
+  parameters:
+    internalCIDRs: [ ] 


### PR DESCRIPTION
The Policy Controller default Constraint Template library schemas have been updated. 

https://cloud.google.com/anthos-config-management/docs/reference/constraint-template-library#k8snoexternalservices 