### PR TITLE
security: update BoA to latest v0.5.2

### DIFF
--- a/2-how-krm-works/app-manifests/base/balancereader.yaml
+++ b/2-how-krm-works/app-manifests/base/balancereader.yaml
@@ -24,7 +24,7 @@ spec:
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.1"
+          value: "v0.5.2"
         - name: PORT
           value: "8080"
         # toggle Cloud Trace export

--- a/2-how-krm-works/app-manifests/base/contacts.yaml
+++ b/2-how-krm-works/app-manifests/base/contacts.yaml
@@ -24,7 +24,7 @@ spec:
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.1"
+          value: "v0.5.2"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/2-how-krm-works/app-manifests/base/frontend.yaml
+++ b/2-how-krm-works/app-manifests/base/frontend.yaml
@@ -24,7 +24,7 @@ spec:
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.1"
+          value: "v0.5.2"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/2-how-krm-works/app-manifests/base/ledgerwriter.yaml
+++ b/2-how-krm-works/app-manifests/base/ledgerwriter.yaml
@@ -24,7 +24,7 @@ spec:
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.1"
+          value: "v0.5.2"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/2-how-krm-works/app-manifests/base/transactionhistory.yaml
+++ b/2-how-krm-works/app-manifests/base/transactionhistory.yaml
@@ -24,7 +24,7 @@ spec:
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.1"
+          value: "v0.5.2"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/2-how-krm-works/app-manifests/base/userservice.yaml
+++ b/2-how-krm-works/app-manifests/base/userservice.yaml
@@ -27,7 +27,7 @@ spec:
           containerPort: 8080
         env:
         - name: VERSION
-          value: "v0.5.1"
+          value: "v0.5.2"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/2-how-krm-works/app-manifests/overlays/prod/balancereader.yaml
+++ b/2-how-krm-works/app-manifests/overlays/prod/balancereader.yaml
@@ -11,7 +11,7 @@ spec:
     spec: 
       containers:
       - name: balancereader
-        image: gcr.io/bank-of-anthos/balancereader:v0.5.1
+        image: gcr.io/bank-of-anthos-ci/balancereader:v0.5.2
         env:
         - name: ENABLE_TRACING
           value: "true"

--- a/2-how-krm-works/app-manifests/overlays/prod/contacts.yaml
+++ b/2-how-krm-works/app-manifests/overlays/prod/contacts.yaml
@@ -11,7 +11,7 @@ spec:
     spec: 
       containers:
       - name: contacts
-        image: gcr.io/bank-of-anthos/contacts:v0.5.1
+        image: gcr.io/bank-of-anthos-ci/contacts:v0.5.2
         env:
         - name: ENABLE_TRACING
           value: "true"

--- a/2-how-krm-works/app-manifests/overlays/prod/frontend.yaml
+++ b/2-how-krm-works/app-manifests/overlays/prod/frontend.yaml
@@ -12,7 +12,7 @@ spec:
     spec: 
       containers:
       - name: front
-        image: gcr.io/bank-of-anthos/frontend:v0.5.1
+        image: gcr.io/bank-of-anthos-ci/frontend:v0.5.2
         env:
         - name: ENABLE_TRACING
           value: "true"

--- a/2-how-krm-works/app-manifests/overlays/prod/ledgerwriter.yaml
+++ b/2-how-krm-works/app-manifests/overlays/prod/ledgerwriter.yaml
@@ -11,7 +11,7 @@ spec:
     spec: 
       containers:
       - name: ledgerwriter
-        image: gcr.io/bank-of-anthos/ledgerwriter:v0.5.1
+        image: gcr.io/bank-of-anthos-ci/ledgerwriter:v0.5.2
         env:
         - name: ENABLE_TRACING
           value: "true"

--- a/2-how-krm-works/app-manifests/overlays/prod/loadgenerator.yaml
+++ b/2-how-krm-works/app-manifests/overlays/prod/loadgenerator.yaml
@@ -11,7 +11,7 @@ spec:
     spec: 
       containers:
       - name: loadgenerator
-        image: gcr.io/bank-of-anthos/loadgenerator:v0.5.1
+        image: gcr.io/bank-of-anthos-ci/loadgenerator:v0.5.2
         env:
         - name: LOG_LEVEL
           value: "info"

--- a/2-how-krm-works/app-manifests/overlays/prod/transactionhistory.yaml
+++ b/2-how-krm-works/app-manifests/overlays/prod/transactionhistory.yaml
@@ -11,7 +11,7 @@ spec:
     spec: 
       containers:
       - name: transactionhistory
-        image: gcr.io/bank-of-anthos/transactionhistory:v0.5.1
+        image: gcr.io/bank-of-anthos-ci/transactionhistory:v0.5.2
         env:
         - name: ENABLE_TRACING
           value: "true"

--- a/2-how-krm-works/app-manifests/overlays/prod/userservice.yaml
+++ b/2-how-krm-works/app-manifests/overlays/prod/userservice.yaml
@@ -11,7 +11,7 @@ spec:
     spec: 
       containers:
       - name: userservice
-        image: gcr.io/bank-of-anthos/userservice:v0.5.1
+        image: gcr.io/bank-of-anthos-ci/userservice:v0.5.2
         env:
         - name: ENABLE_TRACING
           value: "true"

--- a/3-app-dev/README.md
+++ b/3-app-dev/README.md
@@ -10,7 +10,7 @@ If you look inside the `cymbalbank-app-config/` manifests, and look at the `imag
     spec: 
       containers:
       - name: contacts
-        image: gcr.io/bank-of-anthos/contacts:v0.5.1
+        image: gcr.io/bank-of-anthos-ci/contacts:v0.5.2
 ```
 
 In this demo, we'll explore how an app developer can get a new Cymbal Bank feature from their editor into production. 


### PR DESCRIPTION
Following up on https://github.com/askmeegs/build-a-platform-with-krm/pull/32 by integrating latest BoA version [v0.5.2](https://github.com/GoogleCloudPlatform/bank-of-anthos/releases/tag/v0.5.2).